### PR TITLE
Repair CryoSat HTTPS download flow

### DIFF
--- a/cryoswath/l1b.py
+++ b/cryoswath/l1b.py
@@ -42,12 +42,14 @@ import os
 import pandas as pd
 from pathlib import Path
 from pyproj import Transformer
+import requests
 import rioxarray as rioxr
 from scipy.stats import median_abs_deviation, ttest_ind
 import shapely
 from threading import Event
 import tempfile
 import time
+from urllib.parse import parse_qs, urljoin, urlparse
 import warnings
 import xarray as xr
 
@@ -56,7 +58,6 @@ from cryoswath.misc import (
     antenna_baseline,
     cs_time_to_id,
     data_path,
-    download_file as _http_download_file,
     empty_GeoDataFrame,
     ftp_cs2_server,
     gauss_filter_DataArray,
@@ -85,6 +86,10 @@ from cryoswath.gis import (
 from cryoswath.l2 import from_processed_l1b as l2_from_processed_l1b
 
 # requires implicitly rasterio(?), flox(?), dask(?)
+
+_EOCAT_STAC_SEARCH_URL = "https://eocat.esa.int/eo-catalogue/search"
+_ESA_HTTPS_LOGIN_URL = "https://science-pds.cryosat.esa.int/?do=login"
+_ESA_LOGIN_FAILURE_MARKERS = ("authFailure=true", "login.fail.message")
 
 
 def _status(message: str) -> None:
@@ -1205,6 +1210,38 @@ def _https_l1b_base_url(track_id: pd.Timestamp) -> str:
     )
 
 
+def _normalize_l1b_identifier(value: str) -> str:
+    """Return EO-CAT/STAC item id from a filename, URL, or bare stem."""
+    name = str(value).rsplit("/", 1)[-1]
+    if name.endswith(".nc"):
+        name = name[:-3]
+    return name
+
+
+def _resolve_l1b_enclosure_href(
+    identifier_or_filename: str,
+    timeout: int | float = 120,
+) -> str:
+    """Resolve one CryoSat L1b file stem to its EO-CAT enclosure URL."""
+    identifier = _normalize_l1b_identifier(identifier_or_filename)
+    response = requests.get(
+        _EOCAT_STAC_SEARCH_URL,
+        params={"collections": "CryoSat.products", "ids": identifier},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    features = response.json().get("features", [])
+    matching_items = [item for item in features if item.get("id") == identifier]
+    if len(matching_items) != 1:
+        raise FileNotFoundError(
+            f"EO-CAT STAC lookup returned {len(matching_items)} items for {identifier}."
+        )
+    href = matching_items[0].get("assets", {}).get("enclosure", {}).get("href")
+    if not href:
+        raise FileNotFoundError(f"EO-CAT item {identifier} has no enclosure asset.")
+    return href
+
+
 def _validate_netcdf_payload(path: str | Path) -> None:
     """Raise if downloaded payload does not look like NetCDF."""
     path = Path(path)
@@ -1252,26 +1289,101 @@ def _select_lta_then_offl_for_track(track_id: str, remote_files: list[str]) -> s
     raise FileNotFoundError(f"No LTA_ or OFFL product found for track id {track_id}.")
 
 
+def _esa_login_failed(response: requests.Response) -> bool:
+    """Return whether ESA login flow reports an authentication failure."""
+    urls = [response.url] + [item.url for item in response.history]
+    locations = [item.headers.get("location", "") for item in response.history]
+    return any(
+        marker in value
+        for marker in _ESA_LOGIN_FAILURE_MARKERS
+        for value in urls + locations
+    )
+
+
+def _create_esa_https_session(
+    auth: tuple[str, str],
+    timeout: int | float = 120,
+) -> requests.Session:
+    """Create an authenticated ESA HTTPS session for CryoSat downloads."""
+    user, password = auth
+    session = requests.Session()
+    try:
+        login_response = session.get(_ESA_HTTPS_LOGIN_URL, timeout=timeout)
+        session_data_key = parse_qs(urlparse(login_response.url).query).get(
+            "sessionDataKey",
+            [None],
+        )[0]
+        if session_data_key is None:
+            raise RuntimeError(
+                "ESA HTTPS login flow did not expose sessionDataKey for authentication."
+            )
+        auth_response = session.post(
+            urljoin(login_response.url, "../commonauth"),
+            data={
+                "username": user,
+                "password": password,
+                "sessionDataKey": session_data_key,
+            },
+            timeout=timeout,
+        )
+        if _esa_login_failed(auth_response):
+            raise RuntimeError("ESA HTTPS login failed.")
+        return session
+    except Exception:
+        session.close()
+        raise
+
+
+def _download_https_url_atomic(
+    session: requests.Session,
+    url: str,
+    local_path: str | Path,
+    timeout: int | float = 120,
+) -> str:
+    """Download one HTTPS URL to a temporary file, then atomically move."""
+    local_path = Path(local_path)
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=f".{local_path.name}.",
+            suffix=".part",
+            dir=local_path.parent,
+            delete=False,
+        ) as tmp_file:
+            temp_path = Path(tmp_file.name)
+            with session.get(url, stream=True, timeout=timeout) as response:
+                response.raise_for_status()
+                for chunk in response.iter_content(chunk_size=8192):
+                    tmp_file.write(chunk)
+        os.replace(temp_path, local_path)
+    except Exception:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+        raise
+    return str(local_path)
+
+
 def _download_named_file_https(
-    track_id: pd.Timestamp,
     remote_file: str,
     local_path: str | Path,
-    auth: tuple[str, str],
+    session: requests.Session,
 ) -> str:
     """Download one known remote filename via HTTPS."""
     local_path = Path(local_path)
     local_path.parent.mkdir(parents=True, exist_ok=True)
-    base_url = _https_l1b_base_url(track_id)
     candidate_names = _l1b_product_name_candidates(remote_file)
     last_err = None
     for candidate in candidate_names:
         candidate_local_path = local_path.parent / candidate
         try:
+            url = _resolve_l1b_enclosure_href(candidate)
             _status(f"Downloading {candidate} via https.")
-            downloaded = _http_download_file(
-                url=base_url + candidate,
-                dest=candidate_local_path,
-                auth=auth,
+            downloaded = _download_https_url_atomic(
+                session=session,
+                url=url,
+                local_path=candidate_local_path,
                 timeout=120,
             )
             _validate_netcdf_payload(downloaded)
@@ -1420,6 +1532,7 @@ def download_files(
     """Download all missing monthly L1b files for ``track_idx``."""
     track_idx = pd.DatetimeIndex(track_idx).sort_values()
     year_month_str_list = track_idx.strftime(f"%Y{os.path.sep}%m").unique()
+    https_session = None
     try:
         user, password, _ = _resolve_esa_ftp_credentials()
         https_auth = (user, password)
@@ -1442,58 +1555,74 @@ def download_files(
             + ", ".join(str(x) for x in year_month_str_list)
         )
         return
+    try:
+        https_session = _create_esa_https_session(https_auth)
+    except Exception as err:
+        warnings.warn(
+            f"Could not initialize HTTPS session ({err}). Using FTP download.",
+            category=UserWarning,
+        )
+        _download_files_via_ftp(track_idx, stop_event=stop_event)
+        _status(
+            "Finished downloading tracks for months: "
+            + ", ".join(str(x) for x in year_month_str_list)
+        )
+        return
     fallback_tracks = []
-    for year_month_str in year_month_str_list:
-        _status(f"Scanning {year_month_str} for missing files.")
-        if stop_event is not None and stop_event.is_set():
-            return
-        try:
-            currently_present_files = [
-                x[19:] for x in os.listdir(os.path.join(l1b_path, year_month_str))
-            ]
-        except FileNotFoundError:
-            os.makedirs(os.path.join(l1b_path, year_month_str))
-            currently_present_files = []
-        existing_track_ids = {file_name[:15] for file_name in currently_present_files}
-        month_tracks = track_idx[
-            track_idx.strftime(f"%Y{os.path.sep}%m") == year_month_str
-        ]
-        for track_id in month_tracks:
+    try:
+        for year_month_str in year_month_str_list:
+            _status(f"Scanning {year_month_str} for missing files.")
             if stop_event is not None and stop_event.is_set():
                 return
-            track_id_str = track_id.strftime("%Y%m%dT%H%M%S")
-            if track_id_str in existing_track_ids:
-                continue
-            if track_id not in file_names.index:
-                fallback_tracks.append(track_id)
-                continue
-            remote_file = file_names.loc[track_id] + ".nc"
-            local_path = Path(l1b_path, year_month_str, remote_file)
             try:
-                downloaded = Path(
-                    _download_named_file_https(
-                        track_id=track_id,
-                        remote_file=remote_file,
-                        local_path=local_path,
-                        auth=https_auth,
+                currently_present_files = [
+                    x[19:] for x in os.listdir(os.path.join(l1b_path, year_month_str))
+                ]
+            except FileNotFoundError:
+                os.makedirs(os.path.join(l1b_path, year_month_str))
+                currently_present_files = []
+            existing_track_ids = {file_name[:15] for file_name in currently_present_files}
+            month_tracks = track_idx[
+                track_idx.strftime(f"%Y{os.path.sep}%m") == year_month_str
+            ]
+            for track_id in month_tracks:
+                if stop_event is not None and stop_event.is_set():
+                    return
+                track_id_str = track_id.strftime("%Y%m%dT%H%M%S")
+                if track_id_str in existing_track_ids:
+                    continue
+                if track_id not in file_names.index:
+                    fallback_tracks.append(track_id)
+                    continue
+                remote_file = file_names.loc[track_id] + ".nc"
+                local_path = Path(l1b_path, year_month_str, remote_file)
+                try:
+                    downloaded = Path(
+                        _download_named_file_https(
+                            remote_file=remote_file,
+                            local_path=local_path,
+                            session=https_session,
+                        )
                     )
-                )
-                currently_present_files.append(downloaded.name[19:])
-                existing_track_ids.add(track_id_str)
-            except Exception as err:
-                warnings.warn(
-                    "HTTPS download failed for "
-                    f"{remote_file}: {err}. Falling back to FTP.",
-                    category=UserWarning,
-                )
-                fallback_tracks.append(track_id)
-    if fallback_tracks:
-        fallback_tracks = pd.DatetimeIndex(fallback_tracks).unique().sort_values()
-        _download_files_via_ftp(fallback_tracks, stop_event=stop_event)
-    _status(
-        "Finished downloading tracks for months: "
-        + ", ".join(str(x) for x in year_month_str_list)
-    )
+                    currently_present_files.append(downloaded.name[19:])
+                    existing_track_ids.add(track_id_str)
+                except Exception as err:
+                    warnings.warn(
+                        "HTTPS download failed for "
+                        f"{remote_file}: {err}. Falling back to FTP.",
+                        category=UserWarning,
+                    )
+                    fallback_tracks.append(track_id)
+        if fallback_tracks:
+            fallback_tracks = pd.DatetimeIndex(fallback_tracks).unique().sort_values()
+            _download_files_via_ftp(fallback_tracks, stop_event=stop_event)
+        _status(
+            "Finished downloading tracks for months: "
+            + ", ".join(str(x) for x in year_month_str_list)
+        )
+    finally:
+        if https_session is not None:
+            https_session.close()
 
 
 def download_single_file(track_id: str) -> str:
@@ -1515,18 +1644,22 @@ def download_single_file(track_id: str) -> str:
         local_path = Path(
             data_path, "L1b", track_id_timestamp.strftime("%Y/%m"), filename
         )
+        https_session = None
         try:
+            https_session = _create_esa_https_session(https_auth)
             return _download_named_file_https(
-                track_id=track_id_timestamp,
                 remote_file=filename,
                 local_path=local_path,
-                auth=https_auth,
+                session=https_session,
             )
         except Exception as err:
             warnings.warn(
                 f"HTTPS download failed for {filename}: {err}. Falling back to FTP.",
                 category=UserWarning,
             )
+        finally:
+            if https_session is not None:
+                https_session.close()
     else:
         warnings.warn(
             f"No file-name catalog entry found for {track_id}. Falling back to FTP.",

--- a/tests/test_l1b_download_protocol.py
+++ b/tests/test_l1b_download_protocol.py
@@ -1,9 +1,154 @@
+import os
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
 import cryoswath.l1b as l1b
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        *,
+        json_data=None,
+        content: bytes = b"",
+        headers: dict | None = None,
+        url: str = "https://example.com",
+        history: list | None = None,
+        status_code: int = 200,
+    ):
+        self._json_data = json_data
+        self._content = content
+        self.headers = headers or {}
+        self.url = url
+        self.history = history or []
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json_data
+
+    def iter_content(self, chunk_size=8192):
+        if self._content:
+            yield self._content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummySession:
+    def __init__(self, get_responses=None, post_responses=None):
+        self.get_responses = list(get_responses or [])
+        self.post_responses = list(post_responses or [])
+        self.get_calls = []
+        self.post_calls = []
+        self.closed = False
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return self.get_responses.pop(0)
+
+    def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        return self.post_responses.pop(0)
+
+    def close(self):
+        self.closed = True
+
+
+def test_normalize_l1b_identifier():
+    assert (
+        l1b._normalize_l1b_identifier(
+            "https://example.com/files/CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc"
+        )
+        == "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST"
+    )
+
+
+def test_resolve_l1b_enclosure_href_exact_lookup(monkeypatch):
+    expected = "https://science-pds.cryosat.esa.int/?do=download&file=test.nc"
+
+    def fake_get(url, params, timeout):
+        assert url == l1b._EOCAT_STAC_SEARCH_URL
+        assert params == {
+            "collections": "CryoSat.products",
+            "ids": "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST",
+        }
+        return DummyResponse(
+            json_data={
+                "features": [
+                    {
+                        "id": "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST",
+                        "assets": {"enclosure": {"href": expected}},
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(l1b.requests, "get", fake_get)
+    assert (
+        l1b._resolve_l1b_enclosure_href("CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc")
+        == expected
+    )
+
+
+def test_create_esa_https_session_success(monkeypatch):
+    session = DummySession(
+        get_responses=[
+            DummyResponse(
+                url=(
+                    "https://eoiam-idp.eo.esa.int/authenticationendpoint/login.do"
+                    "?sessionDataKey=test-session-key"
+                )
+            )
+        ],
+        post_responses=[DummyResponse(url="https://science-pds.cryosat.esa.int/")],
+    )
+    monkeypatch.setattr(l1b.requests, "Session", lambda: session)
+
+    result = l1b._create_esa_https_session(("esa-user", "esa-password"))
+
+    assert result is session
+    assert session.get_calls[0][0] == l1b._ESA_HTTPS_LOGIN_URL
+    assert session.post_calls[0][0].endswith("/commonauth")
+    assert session.post_calls[0][1]["data"] == {
+        "username": "esa-user",
+        "password": "esa-password",
+        "sessionDataKey": "test-session-key",
+    }
+
+
+def test_create_esa_https_session_raises_on_auth_failure(monkeypatch):
+    session = DummySession(
+        get_responses=[
+            DummyResponse(
+                url=(
+                    "https://eoiam-idp.eo.esa.int/authenticationendpoint/login.do"
+                    "?sessionDataKey=test-session-key"
+                )
+            )
+        ],
+        post_responses=[
+            DummyResponse(
+                url=(
+                    "https://eoiam-idp.eo.esa.int/authenticationendpoint/login.do"
+                    "?authFailure=true&authFailureMsg=login.fail.message"
+                )
+            )
+        ],
+    )
+    monkeypatch.setattr(l1b.requests, "Session", lambda: session)
+
+    with pytest.raises(RuntimeError, match="login failed"):
+        l1b._create_esa_https_session(("esa-user", "esa-password"))
+    assert session.closed
 
 
 def test_download_single_file_prefers_https(monkeypatch, tmp_path):
@@ -20,11 +165,13 @@ def test_download_single_file_prefers_https(monkeypatch, tmp_path):
         lambda idx: pd.Series({track_time: remote_base_name}),
     )
     calls = []
+    session = DummySession()
 
-    def fake_https(track_id, remote_file, local_path, auth):
-        calls.append((track_id, remote_file, Path(local_path), auth))
+    def fake_https(remote_file, local_path, session):
+        calls.append((remote_file, Path(local_path), session))
         return str(local_path)
 
+    monkeypatch.setattr(l1b, "_create_esa_https_session", lambda auth: session)
     monkeypatch.setattr(l1b, "_download_named_file_https", fake_https)
     monkeypatch.setattr(
         l1b,
@@ -35,9 +182,9 @@ def test_download_single_file_prefers_https(monkeypatch, tmp_path):
     )
     result = l1b.download_single_file(track_id)
     assert result.endswith(remote_base_name + ".nc")
-    assert calls[0][0] == track_time
-    assert calls[0][1] == remote_base_name + ".nc"
-    assert calls[0][3] == ("esa-user", "esa-password")
+    assert calls[0][0] == remote_base_name + ".nc"
+    assert calls[0][2] is session
+    assert session.closed
 
 
 def test_download_single_file_falls_back_to_ftp_on_https_failure(monkeypatch, tmp_path):
@@ -52,6 +199,9 @@ def test_download_single_file_falls_back_to_ftp_on_https_failure(monkeypatch, tm
         l1b,
         "_load_cs_full_file_names_for",
         lambda idx: pd.Series({track_time: remote_base_name}),
+    )
+    monkeypatch.setattr(
+        l1b, "_create_esa_https_session", lambda auth: DummySession()
     )
     monkeypatch.setattr(
         l1b,
@@ -82,22 +232,26 @@ def test_download_files_uses_https_and_falls_back_for_unresolved_tracks(
     )
     https_calls = []
     ftp_calls = []
+    session = DummySession()
 
-    def fake_https(track_id, remote_file, local_path, auth):
-        https_calls.append((track_id, remote_file, Path(local_path), auth))
+    def fake_https(remote_file, local_path, session):
+        https_calls.append((remote_file, Path(local_path), session))
         return str(local_path)
 
     def fake_ftp(track_idx, stop_event=None):
         ftp_calls.append(pd.DatetimeIndex(track_idx))
 
+    monkeypatch.setattr(l1b, "_create_esa_https_session", lambda auth: session)
     monkeypatch.setattr(l1b, "_download_named_file_https", fake_https)
     monkeypatch.setattr(l1b, "_download_files_via_ftp", fake_ftp)
     l1b.download_files(track_idx)
     assert len(https_calls) == 1
-    assert https_calls[0][0] == resolved_track
+    assert https_calls[0][0] == remote_base_name + ".nc"
+    assert https_calls[0][2] is session
     assert len(ftp_calls) == 1
     assert unresolved_track in ftp_calls[0]
     assert resolved_track not in ftp_calls[0]
+    assert session.closed
 
 
 def test_download_files_uses_ftp_when_https_auth_is_unavailable(monkeypatch):
@@ -127,42 +281,96 @@ def test_download_files_uses_ftp_when_https_auth_is_unavailable(monkeypatch):
     assert ftp_calls[0].equals(track_idx)
 
 
+def test_download_files_reuses_one_https_session_for_batch(monkeypatch, tmp_path):
+    track_idx = pd.DatetimeIndex(["2020-01-01 00:00:00", "2020-01-02 00:00:00"])
+    remote_base_names = pd.Series(
+        {
+            track_idx[0]: "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST",
+            track_idx[1]: "CS_OFFL_SIR_SIN_1B_20200102T000000_TEST",
+        }
+    )
+    monkeypatch.setattr(l1b, "l1b_path", str(tmp_path))
+    monkeypatch.setattr(
+        l1b, "_resolve_esa_ftp_credentials", lambda: ("esa-user", "esa-password", "env")
+    )
+    monkeypatch.setattr(l1b, "_load_cs_full_file_names_for", lambda idx: remote_base_names)
+    session = DummySession()
+    session_calls = []
+
+    def fake_https(remote_file, local_path, session):
+        session_calls.append((remote_file, session))
+        return str(local_path)
+
+    monkeypatch.setattr(l1b, "_create_esa_https_session", lambda auth: session)
+    monkeypatch.setattr(l1b, "_download_named_file_https", fake_https)
+    monkeypatch.setattr(
+        l1b,
+        "_download_files_via_ftp",
+        lambda track_idx, stop_event=None: (_ for _ in ()).throw(
+            AssertionError("FTP fallback should not be used")
+        ),
+    )
+
+    l1b.download_files(track_idx)
+
+    assert [call[0] for call in session_calls] == [
+        "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc",
+        "CS_OFFL_SIR_SIN_1B_20200102T000000_TEST.nc",
+    ]
+    assert all(call[1] is session for call in session_calls)
+    assert session.closed
+
+
 def test_download_named_file_https_rejects_html_payload(monkeypatch, tmp_path):
-    track_time = pd.to_datetime("2020-01-01 00:00:00")
     remote_file = "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc"
     local_path = tmp_path / remote_file
-
-    def fake_download(url, dest, auth, timeout):
-        Path(dest).write_text("<!DOCTYPE html><html>login page</html>")
-        return str(dest)
-
-    monkeypatch.setattr(l1b, "_http_download_file", fake_download)
+    session = DummySession(
+        get_responses=[
+            DummyResponse(
+                content=b"<!DOCTYPE html><html>login page</html>",
+                headers={"content-type": "text/html"},
+            ),
+            DummyResponse(
+                content=b"<!DOCTYPE html><html>login page</html>",
+                headers={"content-type": "text/html"},
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        l1b,
+        "_resolve_l1b_enclosure_href",
+        lambda value, timeout=120: "https://science-pds.cryosat.esa.int/test.nc",
+    )
 
     with pytest.raises(RuntimeError, match="HTML/XML"):
         l1b._download_named_file_https(
-            track_id=track_time,
             remote_file=remote_file,
             local_path=local_path,
-            auth=("user", "password"),
+            session=session,
         )
     assert not local_path.exists()
 
 
 def test_download_named_file_https_accepts_netcdf4_magic(monkeypatch, tmp_path):
-    track_time = pd.to_datetime("2020-01-01 00:00:00")
     remote_file = "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc"
     local_path = tmp_path / remote_file
-
-    def fake_download(url, dest, auth, timeout):
-        Path(dest).write_bytes(b"\x89HDF\r\n\x1a\n" + b"payload")
-        return str(dest)
-
-    monkeypatch.setattr(l1b, "_http_download_file", fake_download)
+    session = DummySession(
+        get_responses=[
+            DummyResponse(
+                content=b"\x89HDF\r\n\x1a\n" + b"payload",
+                headers={"content-type": "application/x-netcdf"},
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        l1b,
+        "_resolve_l1b_enclosure_href",
+        lambda value, timeout=120: "https://science-pds.cryosat.esa.int/test.nc",
+    )
     result = l1b._download_named_file_https(
-        track_id=track_time,
         remote_file=remote_file,
         local_path=local_path,
-        auth=("user", "password"),
+        session=session,
     )
     assert Path(result).name == "CS_LTA__SIR_SIN_1B_20200101T000000_TEST.nc"
 
@@ -198,28 +406,35 @@ def test_select_lta_then_offl_for_track_raises_when_missing():
 def test_download_named_file_https_falls_back_to_offl_when_lta_missing(
     monkeypatch, tmp_path
 ):
-    track_time = pd.to_datetime("2020-01-01 00:00:00")
     remote_file = "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc"
     local_path = tmp_path / remote_file
+    session = DummySession(
+        get_responses=[
+            DummyResponse(
+                content=b"\x89HDF\r\n\x1a\n" + b"payload",
+                headers={"content-type": "application/x-netcdf"},
+            )
+        ]
+    )
     calls = []
 
-    def fake_download(url, dest, auth, timeout):
-        calls.append(url)
-        if "CS_LTA__SIR_SIN_1B_20200101T000000_TEST.nc" in url:
-            raise RuntimeError("missing LTA")
-        Path(dest).write_bytes(b"\x89HDF\r\n\x1a\n" + b"payload")
-        return str(dest)
+    def fake_resolve(value, timeout=120):
+        calls.append(value)
+        if value.startswith("CS_LTA__"):
+            raise FileNotFoundError("missing LTA")
+        return "https://science-pds.cryosat.esa.int/test.nc"
 
-    monkeypatch.setattr(l1b, "_http_download_file", fake_download)
+    monkeypatch.setattr(l1b, "_resolve_l1b_enclosure_href", fake_resolve)
     result = l1b._download_named_file_https(
-        track_id=track_time,
         remote_file=remote_file,
         local_path=local_path,
-        auth=("user", "password"),
+        session=session,
     )
     assert result == str(local_path)
-    assert "CS_LTA__SIR_SIN_1B_20200101T000000_TEST.nc" in calls[0]
-    assert "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc" in calls[1]
+    assert calls == [
+        "CS_LTA__SIR_SIN_1B_20200101T000000_TEST.nc",
+        "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc",
+    ]
 
 
 def test_download_remote_file_via_ftp_atomic_success(tmp_path):
@@ -250,3 +465,27 @@ def test_download_remote_file_via_ftp_atomic_cleans_temp_on_failure(tmp_path):
         l1b._download_remote_file_via_ftp_atomic(FailingFtp(), "remote.nc", local_path)
     assert not local_path.exists()
     assert list(tmp_path.iterdir()) == []
+
+
+def test_live_download_single_file_prefers_https_when_enabled(monkeypatch, tmp_path):
+    if os.environ.get("CRYOSWATH_RUN_LIVE_ESA") != "1":
+        pytest.skip("Set CRYOSWATH_RUN_LIVE_ESA=1 to run the live ESA HTTPS smoke test.")
+
+    monkeypatch.setattr(l1b, "data_path", str(tmp_path))
+    monkeypatch.setattr(
+        l1b,
+        "_download_single_file_via_ftp",
+        lambda track_id: (_ for _ in ()).throw(
+            AssertionError("Live HTTPS smoke test should not fall back to FTP")
+        ),
+    )
+
+    result = l1b.download_single_file("20230306T025949")
+
+    path = Path(result)
+    assert path.is_file()
+    with path.open("rb") as handle:
+        header = handle.read(16)
+    assert header.startswith(b"\x89HDF\r\n\x1a\n") or header.startswith(
+        (b"CDF\x01", b"CDF\x02", b"CDF\x05")
+    )


### PR DESCRIPTION
Repair CryoSat HTTPS downloads by resolving exact file URLs through EO-CAT STAC and authenticating with an ESA session before fetching from the Science Server. Public download APIs and FTP fallback stay unchanged.

Also adds focused protocol tests for STAC lookup, session login handling, HTML/login-page rejection, per-batch session reuse, and an opt-in live ESA smoke test.