### PR TITLE
Fix xarray MultiIndex warning in hypsometric interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog is intentionally lightweight. It records user-visible changes and
 ## Unreleased
 
 - Report PGC STAC API timeout and connectivity failures with a clear runtime error.
+- Avoid xarray MultiIndex deprecation warnings during hypsometric void filling.
 
 ## 0.2.6 - 2026-05-17
 

--- a/cryoswath/misc.py
+++ b/cryoswath/misc.py
@@ -1949,6 +1949,15 @@ def interpolate_hypsometrically(
         else:
             return ds
 
+    def temporary_mask(mask):
+        if (
+            isinstance(mask, xr.DataArray)
+            and "stacked_x_y" in mask.dims
+            and "stacked_x_y" in mask.xindexes
+        ):
+            return mask.reset_index("stacked_x_y", drop=True)
+        return mask
+
     def design_matrix(x_vals):
         return np.hstack([x_vals, x_vals**2, x_vals**3])
 
@@ -2115,7 +2124,7 @@ def interpolate_hypsometrically(
     )
     elev_bin_means = pd.Series(index=group_obj.groups)
     elev_bin_errs = pd.Series(index=group_obj.groups)
-    fill_mask = -1 * xr.ones_like(ds[main_var])
+    fill_mask = temporary_mask(-1 * xr.ones_like(ds[main_var]))
     for label, group in group_obj:
         if (group[weights] > 0).sum() < 6:
             continue
@@ -2136,6 +2145,7 @@ def interpolate_hypsometrically(
         to_be_filled_mask = xr.align(
             fill_mask, to_be_filled_mask, join="left", fill_value=-1
         )[1]
+        to_be_filled_mask = temporary_mask(to_be_filled_mask)
         fill_mask = xr.where(to_be_filled_mask != -1, to_be_filled_mask, fill_mask)
         if np.isnan(avg):
             # print("calc weighted avg failed (probably insufficient data)", label)
@@ -2212,8 +2222,8 @@ def interpolate_hypsometrically(
             np.polyval(np.polyder(coeffs), scale(pivot)) * (scale(data) - scale(pivot))
         ).flatten() + const_extrapol(data, pivot)
 
-    extrap_below = ds[elev] < elev_bin_means.index[0].mid
-    extrap_above = ds[elev] > elev_bin_means.index[-1].mid
+    extrap_below = temporary_mask(ds[elev] < elev_bin_means.index[0].mid)
+    extrap_above = temporary_mask(ds[elev] > elev_bin_means.index[-1].mid)
     modelled_list = [
         xr.DataArray(
             fit.predict(design_matrix(scale(ds[elev]))),
@@ -2278,9 +2288,11 @@ def interpolate_hypsometrically(
     #       neighbour_mean-modelled) - outlier_limit * neighbour_std.mean()
     # ).unstack().sortby("x").sortby("y").T.plot(robust=True, cmap="RdYlBu")
     # plt.show()
-    local_deviation = np.logical_and(
-        neighbour_count >= 6,
-        np.abs(neighbour_mean - modelled) > outlier_limit * neighbour_std.mean(),
+    local_deviation = temporary_mask(
+        np.logical_and(
+            neighbour_count >= 6,
+            np.abs(neighbour_mean - modelled) > outlier_limit * neighbour_std.mean(),
+        )
     )
     modelled = xr.where(local_deviation, neighbour_mean, modelled)
     if outlier_replace:

--- a/tests/test_hypsometric_interpolation.py
+++ b/tests/test_hypsometric_interpolation.py
@@ -1,0 +1,35 @@
+import warnings
+
+import numpy as np
+import xarray as xr
+
+import cryoswath.misc as misc
+
+
+def test_interpolate_hypsometrically_avoids_multiindex_drop_warning():
+    x = np.arange(6)
+    y = np.arange(6)
+    ref_elev = (x[:, None] * 10 + y[None, :]).astype(float)
+    values = ref_elev * 0.1 + 5
+    values[1, 1] = np.nan
+    values[2, 3] = np.nan
+    values[4, 4] = np.nan
+    ds = xr.Dataset(
+        {
+            "dh": (("x", "y"), values),
+            "dh_std": (("x", "y"), np.ones_like(values)),
+            "ref_elev": (("x", "y"), ref_elev),
+        },
+        coords={"x": x, "y": y},
+    ).stack(stacked_x_y=["x", "y"])
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message="Deleting a single level of a MultiIndex is deprecated.*",
+            category=Warning,
+        )
+        result = misc.interpolate_hypsometrically(ds, "dh", "dh_std")
+
+    assert "stacked_x_y" in result.dims
+    assert result["dh"].sizes["stacked_x_y"] == ds["dh"].sizes["stacked_x_y"]


### PR DESCRIPTION
Summary
- Avoid deprecated xarray MultiIndex level deletion during stacked void-filling interpolation.
- Keep stacked data unstackable while simplifying temporary boolean masks.
- Add regression coverage for the FutureWarning reported with xarray 2026.4.0.
- Add changelog entry.

Closes #69

Tests
- Direct hypsometric regression smoke check
- python -m py_compile cryoswath/misc.py tests/test_hypsometric_interpolation.py