### PR TITLE
Allow fill_voids with precomputed groupers and no basin shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog is intentionally lightweight. It records user-visible changes and
 
 - Report PGC STAC API timeout and connectivity failures with a clear runtime error.
 - Avoid xarray MultiIndex deprecation warnings during hypsometric void filling.
+- Allow `fill_voids` to use existing basin/group IDs without requiring basin shape files.
 
 ## 0.2.6 - 2026-05-17
 

--- a/cryoswath/l4.py
+++ b/cryoswath/l4.py
@@ -433,27 +433,45 @@ def fill_voids(
     """
     if any([grouper not in ["basin", "basin_group"] for grouper in per]):
         raise NotImplementedError
-    if basin_shapes is None:
+    grouper_vars = {"basin": "basin_id", "basin_group": "group_id"}
+    needs_basin_shapes = any(grouper_vars[grouper] not in ds for grouper in per)
+    if basin_shapes is None and needs_basin_shapes:
         # figure out region. limited to o2 meanwhile
         print("... loading basin outlines")
         o2code = find_region_id(ds, scope="o2")
         basin_shapes = load_glacier_outlines(
             o2code, product="glaciers", union=False, crs=ds.rio.crs
         )
-    else:
+    elif basin_shapes is not None:
         basin_shapes = basin_shapes.to_crs(ds.rio.crs)
+
+    def grouper_domain_mask(ds: xr.Dataset) -> xr.DataArray | None:
+        if "basin_id" in ds:
+            return ~ds.basin_id.isnull()
+        if "group_id" in ds:
+            return ~ds.group_id.isnull()
+        return None
+
     # remove time steps without any data
     if "time" in ds.dims:
         ds = ds.dropna("time", how="all", subset=[main_var])
     # polygons will be repaired in later functions. it may be more
     # transparent to do it here.
-    ds = fill_missing_coords(ds, *basin_shapes.total_bounds)
+    if basin_shapes is None:
+        ds = fill_missing_coords(ds)
+    else:
+        ds = fill_missing_coords(ds, *basin_shapes.total_bounds)
     if (
         elev not in ds
     ):  # tbi: the ref elevs should always be loaded again after fill missing coords!
         print("... appending reference DEM to dataset")
         ds = append_elevation_reference(ds, ref_elev_name=elev)
-    ds[elev] = ds[elev].rio.clip(basin_shapes.make_valid())
+    if basin_shapes is None:
+        domain_mask = grouper_domain_mask(ds)
+        if domain_mask is not None:
+            ds[elev] = ds[elev].where(domain_mask)
+    else:
+        ds[elev] = ds[elev].rio.clip(basin_shapes.make_valid())
     ref_elev_da = ds[elev].copy()
     for grouper in per:
         res = []
@@ -566,27 +584,33 @@ def fill_voids(
         ds[main_var] = _new_main
     # if there are still missing data, interpolate region wide ("global
     # hypsometric interpolation")
-    ds = interpolate_hypsometrically(
-        (
-            ds.where(
-                ~ds.basin_id.isnull(),
-                xr.Dataset(
-                    {
-                        _var: (
-                            ds[_var].attrs["_FillValue"]
-                            if "_FillValue" in ds[_var].attrs
-                            else np.nan
-                        )
-                        for _var in ds.data_vars
-                    }
-                ),
-            )
-            if "basin_id" in ds
-            else ds
+    global_input = (
+        ds.where(
+            ~ds.basin_id.isnull(),
+            xr.Dataset(
+                {
+                    _var: (
+                        ds[_var].attrs["_FillValue"]
+                        if "_FillValue" in ds[_var].attrs
+                        else np.nan
+                    )
+                    for _var in ds.data_vars
+                }
+            ),
         )
-        .rio.clip(basin_shapes.make_valid())
-        .stack({"stacked_x_y": ["x", "y"]})
-        .dropna("stacked_x_y", how="any", subset=[elev]),
+        if "basin_id" in ds
+        else ds
+    )
+    if basin_shapes is None:
+        domain_mask = grouper_domain_mask(global_input)
+        if domain_mask is not None:
+            global_input = global_input.where(domain_mask)
+    else:
+        global_input = global_input.rio.clip(basin_shapes.make_valid())
+    ds = interpolate_hypsometrically(
+        global_input.stack({"stacked_x_y": ["x", "y"]}).dropna(
+            "stacked_x_y", how="any", subset=[elev]
+        ),
         main_var=main_var,
         elev=elev,
         error=error,

--- a/tests/test_l4_fill_voids.py
+++ b/tests/test_l4_fill_voids.py
@@ -1,0 +1,50 @@
+import numpy as np
+import xarray as xr
+
+import cryoswath.l4 as l4
+
+
+def test_fill_voids_uses_existing_groupers_without_basin_shapes(monkeypatch):
+    x = np.arange(3)
+    y = np.arange(3)
+    values = np.ones((3, 3), dtype=float)
+    values[0, 0] = np.nan
+    values[1, 1] = np.nan
+    basin_id = np.ones((3, 3), dtype=float)
+    basin_id[1, 1] = np.nan
+    group_id = np.ones((3, 3), dtype=float)
+    group_id[1, 1] = np.nan
+    ds = xr.Dataset(
+        {
+            "dh": (("x", "y"), values),
+            "dh_std": (("x", "y"), np.ones_like(values)),
+            "ref_elev": (("x", "y"), np.arange(9).reshape(3, 3).astype(float)),
+            "basin_id": (("x", "y"), basin_id),
+            "group_id": (("x", "y"), group_id),
+        },
+        coords={"x": x, "y": y},
+    )
+
+    def fail(*args, **kwargs):
+        raise AssertionError("shape loading or ID assignment should not be called")
+
+    def fake_interpolate(ds, main_var, *args, **kwargs):
+        return ds.assign({main_var: ds[main_var].fillna(99)})
+
+    monkeypatch.setattr(l4, "find_region_id", fail)
+    monkeypatch.setattr(l4, "load_glacier_outlines", fail)
+    monkeypatch.setattr(l4, "append_basin_id", fail)
+    monkeypatch.setattr(l4, "append_basin_group", fail)
+    monkeypatch.setattr(l4, "interpolate_hypsometrically", fake_interpolate)
+
+    result = l4.fill_voids(
+        ds,
+        "dh",
+        "dh_std",
+        per=("basin", "basin_group"),
+        basin_shapes=None,
+        discard_deglaciated=False,
+    )
+
+    assert result["dh"].sel(x=0, y=0) == 99
+    assert np.isnan(result["dh"].sel(x=1, y=1))


### PR DESCRIPTION
Summary
- Let fill_voids run without basin shape files when requested grouping variables already exist.
- Skip outline loading, ID reassignment, and shape clipping in the shape-free path.
- Use existing basin/group ID nullness as the fill domain mask.
- Preserve existing shape-based behavior when requested groupers are missing.
- Add changelog entry.

Closes #70

Tests
- Direct l4 fill_voids regression smoke check
- python -m py_compile cryoswath/l4.py tests/test_l4_fill_voids.py