### PR TITLE
Fix failing readthedocs builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: sync-dependency-definitions
         name: Sync dependency definitions
-        entry: bash scripts/sync_dependency_definitions.sh
+        entry: bash tools/sync_dependency_definitions.sh
         language: system
         pass_filenames: false
         files: ^(pyproject\.toml|pixi\.toml|environment\.yml|conda-pypi-map\.json)$

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 conda:
-  environment: environment.yml
+  environment: docs/environment.yml
 
 # Set the OS, Python version, and other tools you might need
 build:
@@ -16,8 +16,3 @@ build:
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
    configuration: docs/conf.py
-
-# Install theme
-python:
-  install:
-    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,8 @@ build:
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
    configuration: docs/conf.py
+
+# Install theme
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,40 @@
+name: docs
+channels:
+- conda-forge
+- nodefaults
+- nodefaults
+dependencies:
+- sphinx *
+- pydata-sphinx-theme *
+- python 3.12.*
+- bottleneck *
+- dask *
+- defusedxml *
+- earthaccess >=0.18
+- geopandas >=1.0.1
+- h5netcdf *
+- h5py *
+- keyring *
+- matplotlib *
+- numpy *
+- packaging *
+- pandas >=2,<3
+- pyarrow *
+- pyogrio *
+- pyproj *
+- pystac-client *
+- python-dateutil *
+- rasterio *
+- rioxarray *
+- scikit-learn *
+- scipy *
+- shapely *
+- stackstac *
+- statsmodels *
+- pytables *
+- tqdm *
+- xarray >=2026.3
+- zarr *
+- pip
+- pip:
+  - -e .

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -37,4 +37,4 @@ dependencies:
 - zarr *
 - pip
 - pip:
-  - -e .
+  - ..

--- a/tools/sync_environment_yml_from_pixi.sh
+++ b/tools/sync_environment_yml_from_pixi.sh
@@ -30,9 +30,10 @@ fi
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 env_yaml="$repo_root/environment.yml"
 tmp_yaml="$(mktemp)"
+docs_yaml="$(mktemp)"
 
 cleanup() {
-  rm -f "$tmp_yaml"
+  rm -f "$tmp_yaml" "$docs_yaml"
 }
 trap cleanup EXIT
 
@@ -41,6 +42,11 @@ trap cleanup EXIT
   -e default \
   -p linux-64 \
   "$tmp_yaml" >/dev/null
+"$pixi_exe" workspace export conda-environment \
+  --manifest-path "$repo_root" \
+  -e docs \
+  -p linux-64 \
+  "$docs_yaml" >/dev/null
 
 if [[ "$mode" == "check" ]]; then
   if [[ -f "$env_yaml" ]] && cmp -s "$env_yaml" "$tmp_yaml"; then
@@ -64,4 +70,5 @@ if [[ -f "$env_yaml" ]] && cmp -s "$env_yaml" "$tmp_yaml"; then
 fi
 
 mv "$tmp_yaml" "$env_yaml"
+mv "$docs_yaml" "$repo_root/docs/environment.yml"
 echo "Updated $env_yaml from the Pixi default environment."

--- a/tools/sync_environment_yml_from_pixi.sh
+++ b/tools/sync_environment_yml_from_pixi.sh
@@ -47,6 +47,7 @@ trap cleanup EXIT
   -e docs \
   -p linux-64 \
   "$docs_yaml" >/dev/null
+sed -i 's/\( \+\|\t\+\)-\( -e\)\? \./\1- ../' "$docs_yaml"
 
 if [[ "$mode" == "check" ]]; then
   if [[ -f "$env_yaml" ]] && cmp -s "$env_yaml" "$tmp_yaml"; then


### PR DESCRIPTION
Adds a docs specific environment.yml using the synchronization script. This approach is meant to automatically update the env file when there are dependency changes through a pre-commit-hook.