### PR TITLE
Use MAAP metadata for L1b downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog is intentionally lightweight. It records user-visible changes and
 
 ## Unreleased
 
+- Use MAAP CryoSat STAC metadata with authenticated PDS HTTPS delivery for L1b
+  downloads, and fail fast rather than automatically falling back to FTP.
 - Add STAC-backed CryoSat SARIn L1b track discovery with a richer local cache,
   deterministic baseline/version selection, and legacy local-cache fallback.
 - Report PGC STAC API timeout and connectivity failures with a clear runtime error.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ from waveform-level processing to gridded elevation products.
   `name/password` (temporary fallback).
 - Automatic RGI downloads from NSIDC require NASA Earthdata credentials;
   see the prerequisites docs for setup details.
-- L1b file downloads are HTTPS-first. CryoSat SARIn L1b track discovery uses
-  a local cache when possible and can extend it from ESA STAC metadata; FTP
-  remains a fallback path for legacy metadata and data access.
+- CryoSat SARIn L1b track discovery uses a local cache when possible and
+  refreshes missing metadata from ESA MAAP. Selected products are downloaded
+  through authenticated PDS HTTPS; normal download workflows do not fall back
+  to FTP.
 - Anonymous FTP login is no longer supported.
 - Install `xarray` and `zarr` together to avoid version mismatches.
 

--- a/cryoswath/l1b.py
+++ b/cryoswath/l1b.py
@@ -90,7 +90,6 @@ from cryoswath.misc import (
 
 # requires implicitly rasterio(?), flox(?), dask(?)
 
-_EOCAT_STAC_SEARCH_URL = "https://eocat.esa.int/eo-catalogue/search"
 _ESA_HTTPS_LOGIN_URL = "https://science-pds.cryosat.esa.int/?do=login"
 _ESA_LOGIN_FAILURE_MARKERS = ("authFailure=true", "login.fail.message")
 
@@ -1223,36 +1222,23 @@ def _https_l1b_base_url(track_id: pd.Timestamp) -> str:
     )
 
 
-def _normalize_l1b_identifier(value: str) -> str:
-    """Return EO-CAT/STAC item id from a filename, URL, or bare stem."""
-    name = str(value).rsplit("/", 1)[-1]
-    if name.endswith(".nc"):
-        name = name[:-3]
-    return name
+def _pds_l1b_download_url(remote_file: str) -> str:
+    """Build the authenticated PDS HTTPS URL for a selected L1b filename."""
+    filename = Path(remote_file).name
+    if len(filename) < 34:
+        raise ValueError(f"Could not extract a CryoSat timestamp from {remote_file!r}.")
+    timestamp = pd.to_datetime(filename[19:34])
+    return _https_l1b_base_url(timestamp) + filename
 
 
-def _resolve_l1b_enclosure_href(
-    identifier_or_filename: str,
-    timeout: int | float = 120,
-) -> str:
-    """Resolve one CryoSat L1b file stem to its EO-CAT enclosure URL."""
-    identifier = _normalize_l1b_identifier(identifier_or_filename)
-    response = requests.get(
-        _EOCAT_STAC_SEARCH_URL,
-        params={"collections": "CryoSat.products", "ids": identifier},
-        timeout=timeout,
+def _pds_download_error(failures: list[tuple[str, str]]) -> RuntimeError:
+    """Return a concise error for PDS failures without automatic FTP fallback."""
+    details = "; ".join(f"{track_id}: {reason}" for track_id, reason in failures)
+    return RuntimeError(
+        "CryoSat L1b download via PDS HTTPS failed; automatic FTP fallback is "
+        f"disabled. Failed product(s): {details}. For future MAAP data delivery, "
+        f"see enhancement #76."
     )
-    response.raise_for_status()
-    features = response.json().get("features", [])
-    matching_items = [item for item in features if item.get("id") == identifier]
-    if len(matching_items) != 1:
-        raise FileNotFoundError(
-            f"EO-CAT STAC lookup returned {len(matching_items)} items for {identifier}."
-        )
-    href = matching_items[0].get("assets", {}).get("enclosure", {}).get("href")
-    if not href:
-        raise FileNotFoundError(f"EO-CAT item {identifier} has no enclosure asset.")
-    return href
 
 
 def _validate_netcdf_payload(path: str | Path) -> None:
@@ -1386,39 +1372,24 @@ def _download_named_file_https(
     session: requests.Session,
     href: str | None = None,
 ) -> str:
-    """Download one known remote filename via HTTPS."""
+    """Download one selected L1b filename from authenticated PDS HTTPS."""
     local_path = Path(local_path)
     local_path.parent.mkdir(parents=True, exist_ok=True)
-    if href is not None:
-        _status(f"Downloading {remote_file} via https.")
+    _ = href  # MAAP enclosure URLs remain catalog provenance, not delivery URLs.
+    _status(f"Downloading {remote_file} via PDS https.")
+    try:
         downloaded = _download_https_url_atomic(
             session=session,
-            url=href,
+            url=_pds_l1b_download_url(remote_file),
             local_path=local_path,
             timeout=120,
         )
         _validate_netcdf_payload(downloaded)
         return downloaded
-    candidate_names = _l1b_product_name_candidates(remote_file)
-    last_err = None
-    for candidate in candidate_names:
-        candidate_local_path = local_path.parent / candidate
-        try:
-            url = _resolve_l1b_enclosure_href(candidate)
-            _status(f"Downloading {candidate} via https.")
-            downloaded = _download_https_url_atomic(
-                session=session,
-                url=url,
-                local_path=candidate_local_path,
-                timeout=120,
-            )
-            _validate_netcdf_payload(downloaded)
-            return downloaded
-        except Exception as err:
-            last_err = err
-            if candidate_local_path.is_file():
-                candidate_local_path.unlink()
-    raise last_err
+    except Exception:
+        if local_path.is_file():
+            local_path.unlink()
+        raise
 
 
 def _download_remote_file_via_ftp_atomic(
@@ -1483,25 +1454,15 @@ def _load_cs_l1b_track_catalog_for(
 
 
 def _load_cs_full_file_names_for(track_idx: pd.DatetimeIndex) -> pd.Series | None:
-    """Load and refresh file-name catalog once for missing track IDs."""
+    """Load the local legacy file-name catalog without refreshing it over FTP."""
     try:
-        file_names = load_cs_full_file_names(update="no")
+        return load_cs_full_file_names(update="no")
     except Exception as err:
         warnings.warn(
-            f"Could not load local file-name catalog: {err}. Falling back to FTP.",
+            f"Could not load local legacy file-name catalog: {err}.",
             category=UserWarning,
         )
         return None
-    if not track_idx.isin(file_names.index).all():
-        try:
-            file_names = load_cs_full_file_names(update="regular")
-        except Exception as err:
-            warnings.warn(
-                "Could not refresh file-name catalog via FTP update: "
-                f"{err}. Falling back to FTP for unresolved tracks.",
-                category=UserWarning,
-            )
-    return file_names
 
 
 def _download_files_via_ftp(
@@ -1597,39 +1558,21 @@ def download_files(
         user, password, _ = _resolve_esa_ftp_credentials()
         https_auth = (user, password)
     except RuntimeError as err:
-        warnings.warn(
-            f"Could not configure HTTPS credentials ({err}). Using FTP download.",
-            category=UserWarning,
-        )
-        _download_files_via_ftp(track_idx, stop_event=stop_event)
-        _status(
-            "Finished downloading tracks for months: "
-            + ", ".join(str(x) for x in year_month_str_list)
-        )
-        return
+        raise RuntimeError(f"Could not configure PDS HTTPS credentials: {err}") from err
     track_catalog = _load_cs_l1b_track_catalog_for(track_idx)
     file_names = _load_cs_full_file_names_for(track_idx)
     if file_names is None and (track_catalog is None or track_catalog.empty):
-        _download_files_via_ftp(track_idx, stop_event=stop_event)
-        _status(
-            "Finished downloading tracks for months: "
-            + ", ".join(str(x) for x in year_month_str_list)
+        raise _pds_download_error(
+            [
+                (track.strftime("%Y%m%dT%H%M%S"), "no MAAP or local filename entry")
+                for track in track_idx
+            ]
         )
-        return
     try:
         https_session = _create_esa_https_session(https_auth)
     except Exception as err:
-        warnings.warn(
-            f"Could not initialize HTTPS session ({err}). Using FTP download.",
-            category=UserWarning,
-        )
-        _download_files_via_ftp(track_idx, stop_event=stop_event)
-        _status(
-            "Finished downloading tracks for months: "
-            + ", ".join(str(x) for x in year_month_str_list)
-        )
-        return
-    fallback_tracks = []
+        raise RuntimeError(f"Could not initialize PDS HTTPS session: {err}") from err
+    failures = []
     try:
         for year_month_str in year_month_str_list:
             _status(f"Scanning {year_month_str} for missing files.")
@@ -1666,7 +1609,7 @@ def download_files(
                     remote_file = file_names.loc[track_id] + ".nc"
                     href = None
                 else:
-                    fallback_tracks.append(track_id)
+                    failures.append((track_id_str, "no MAAP or local filename entry"))
                     continue
                 local_path = Path(l1b_path, year_month_str, remote_file)
                 try:
@@ -1681,15 +1624,9 @@ def download_files(
                     currently_present_files.append(downloaded.name[19:])
                     existing_track_ids.add(track_id_str)
                 except Exception as err:
-                    warnings.warn(
-                        "HTTPS download failed for "
-                        f"{remote_file}: {err}. Falling back to FTP.",
-                        category=UserWarning,
-                    )
-                    fallback_tracks.append(track_id)
-        if fallback_tracks:
-            fallback_tracks = pd.DatetimeIndex(fallback_tracks).unique().sort_values()
-            _download_files_via_ftp(fallback_tracks, stop_event=stop_event)
+                    failures.append((track_id_str, f"{remote_file}: {err}"))
+        if failures:
+            raise _pds_download_error(failures)
         _status(
             "Finished downloading tracks for months: "
             + ", ".join(str(x) for x in year_month_str_list)
@@ -1707,11 +1644,7 @@ def download_single_file(track_id: str) -> str:
         user, password, _ = _resolve_esa_ftp_credentials()
         https_auth = (user, password)
     except RuntimeError as err:
-        warnings.warn(
-            f"Could not configure HTTPS credentials ({err}). Using FTP download.",
-            category=UserWarning,
-        )
-        return _download_single_file_via_ftp(track_id)
+        raise RuntimeError(f"Could not configure PDS HTTPS credentials: {err}") from err
     requested_idx = pd.DatetimeIndex([track_id_timestamp])
     track_catalog = _load_cs_l1b_track_catalog_for(requested_idx)
     catalog_row = None
@@ -1740,19 +1673,11 @@ def download_single_file(track_id: str) -> str:
                 href=href,
             )
         except Exception as err:
-            warnings.warn(
-                f"HTTPS download failed for {filename}: {err}. Falling back to FTP.",
-                category=UserWarning,
-            )
+            raise _pds_download_error([(track_id, f"{filename}: {err}")]) from err
         finally:
             if https_session is not None:
                 https_session.close()
-    else:
-        warnings.warn(
-            f"No file-name catalog entry found for {track_id}. Falling back to FTP.",
-            category=UserWarning,
-        )
-    return _download_single_file_via_ftp(track_id)
+    raise _pds_download_error([(track_id, "no MAAP or local filename entry")])
 
 
 def drop_waveform(cs_l1b_ds, time_20_ku_mask):

--- a/cryoswath/misc.py
+++ b/cryoswath/misc.py
@@ -135,8 +135,11 @@ from cryoswath import gis
 _PGC_STAC_API_URL = "https://stac.pgc.umn.edu/api/v1/"
 _PGC_STAC_TIMEOUT = (10, 60)
 _CRYOSAT_STAC_PROVIDERS = (
-    ("eocat", "https://eocat.esa.int/eo-catalogue/search"),
-    ("maap", "https://catalog.maap.eo.esa.int/catalogue/search"),
+    (
+        "maap",
+        "https://catalog.maap.eo.esa.int/catalogue/search",
+        "CryoSatIceL110",
+    ),
 )
 _CRYOSAT_STAC_TIMEOUT = (10, 60)
 _CRYOSAT_STAC_LIMIT = 500
@@ -2441,6 +2444,16 @@ def _extract_stac_l1b_filename(item_id: str, href: str | None) -> str:
     return f"{item_id}.nc"
 
 
+def _stac_l1b_enclosure_href(item: dict[str, Any]) -> str | None:
+    """Return a NetCDF enclosure URL from an ESA CryoSat STAC item."""
+    assets = item.get("assets", {})
+    for key in ("enclosure_nc", "enclosure"):
+        href = assets.get(key, {}).get("href")
+        if href:
+            return href
+    return None
+
+
 def _cryosat_stage_from_filename(filename: str) -> str:
     """Return the CryoSat product stage token from an ESA filename."""
     if filename.startswith("CS_") and len(filename) >= 7:
@@ -2523,7 +2536,7 @@ def _stac_items_to_l1b_track_catalog(
         product_type = properties.get("product:type")
         if product_type != _CRYOSAT_STAC_PRODUCT_TYPE:
             continue
-        href = item.get("assets", {}).get("enclosure", {}).get("href")
+        href = _stac_l1b_enclosure_href(item)
         filename = _extract_stac_l1b_filename(item_id, href)
         start_datetime, end_datetime = _cryosat_item_times(item, item_id)
         product_version = properties.get("version")
@@ -2690,21 +2703,26 @@ def _query_stac_l1b_track_catalog(
 ) -> gpd.GeoDataFrame:
     """Query ESA STAC providers for CryoSat SARIn L1B track metadata."""
     params = {
-        "collections": "CryoSat.products",
         "datetime": _stac_datetime_range(start_datetime, end_datetime),
         "productType": _CRYOSAT_STAC_PRODUCT_TYPE,
         "sensorMode": _CRYOSAT_STAC_SENSOR_MODE,
         "limit": str(_CRYOSAT_STAC_LIMIT),
     }
     errors = []
-    for provider, url in _CRYOSAT_STAC_PROVIDERS:
+    for provider, url, collection in _CRYOSAT_STAC_PROVIDERS:
         try:
-            features = _stac_search_features(url, params)
+            features = _stac_search_features(url, {"collections": collection, **params})
         except Exception as err:
             errors.append(f"{provider}: {err}")
             continue
-        return _stac_items_to_l1b_track_catalog(features, provider)
-    raise RuntimeError("Could not query CryoSat STAC providers. " + "; ".join(errors))
+        catalog = _stac_items_to_l1b_track_catalog(features, provider)
+        if not catalog.empty:
+            return catalog
+    if errors:
+        raise RuntimeError(
+            "Could not query CryoSat STAC metadata. " + "; ".join(errors)
+        )
+    return _empty_cs_l1b_track_catalog()
 
 
 def _refresh_cs_l1b_track_catalog(

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -138,9 +138,11 @@ now, but are deprecated and should be replaced.
 Download protocol defaults
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-L1b data downloads are HTTPS-first by default. FTP remains available as an
-automatic fallback for download failures and is still used for metadata
-refresh flows that compare local catalogs with upstream.
+L1b workflows use MAAP STAC metadata (``CryoSatIceL110``) to discover missing
+CryoSat SARIn products. The selected filename is downloaded through
+authenticated PDS HTTPS. Automatic FTP fallback is disabled for normal
+download workflows so failures identify the affected product instead of
+waiting on legacy FTP data connections.
 
 Data dependencies
 -----------------
@@ -168,17 +170,19 @@ auxiliary-data snapshot from Zenodo DOI ``10.5281/zenodo.20241526`` and
 extracts it into ``data/auxiliary`` by default. The snapshot contains the
 CryoSat-2 ground-track database, filename catalog, and static RGI metadata.
 Newer installations may also contain the richer
-``CryoSat-2_SARIn_L1B_track_catalog.feather`` cache, which stores ESA STAC
-item IDs, product filenames, download URLs, product versions, processing dates,
-and track geometries for supported ``SIR_SIN_1B`` products.
+``CryoSat-2_SARIn_L1B_track_catalog.feather`` cache, which stores MAAP STAC
+item IDs, product filenames, MAAP enclosure URLs, product versions, processing
+dates, and track geometries for supported ``SIR_SIN_1B`` products. MAAP
+enclosure URLs are retained as catalog provenance; current downloads use the
+selected filename with PDS HTTPS.
 
 By default, :func:`cryoswath.misc.load_cs_ground_tracks` uses local track
 caches when their latest timestamp covers the requested period. If the request
 extends beyond local coverage and a network connection is available, CryoSwath
-queries ESA STAC metadata, caches the supported products, and then returns the
+queries MAAP STAC metadata, caches the supported products, and then returns the
 combined local result. Pass ``source="local"`` to force offline/local-only
-behavior, or ``source="stac"`` to force a STAC metadata query for the requested
-period.
+behavior, or ``source="stac"`` to force a MAAP STAC metadata query for the
+requested period.
 
 The STAC-backed selector currently accepts validated CryoSat Baseline D/E
 ``SIR_SIN_1B`` products. If a newer unsupported baseline is seen, CryoSwath

--- a/tests/test_l1b_download_protocol.py
+++ b/tests/test_l1b_download_protocol.py
@@ -72,39 +72,12 @@ def no_implicit_stac_catalog_refresh(monkeypatch):
     )
 
 
-def test_normalize_l1b_identifier():
-    assert (
-        l1b._normalize_l1b_identifier(
-            "https://example.com/files/CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc"
-        )
-        == "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST"
-    )
+def test_pds_l1b_download_url_uses_selected_filename():
+    filename = "CS_OFFL_SIR_SIN_1B_20220917T082319_20220917T082404_E001.nc"
 
-
-def test_resolve_l1b_enclosure_href_exact_lookup(monkeypatch):
-    expected = "https://science-pds.cryosat.esa.int/?do=download&file=test.nc"
-
-    def fake_get(url, params, timeout):
-        assert url == l1b._EOCAT_STAC_SEARCH_URL
-        assert params == {
-            "collections": "CryoSat.products",
-            "ids": "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST",
-        }
-        return DummyResponse(
-            json_data={
-                "features": [
-                    {
-                        "id": "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST",
-                        "assets": {"enclosure": {"href": expected}},
-                    }
-                ]
-            }
-        )
-
-    monkeypatch.setattr(l1b.requests, "get", fake_get)
-    assert (
-        l1b._resolve_l1b_enclosure_href("CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc")
-        == expected
+    assert l1b._pds_l1b_download_url(filename) == (
+        "https://science-pds.cryosat.esa.int/?do=download&file="
+        "Cry0Sat2_data%2FSIR_SIN_L1%2F2022%2F09%2F" + filename
     )
 
 
@@ -264,7 +237,7 @@ def test_download_single_file_uses_stac_catalog_href(monkeypatch, tmp_path):
     assert session.closed
 
 
-def test_download_single_file_falls_back_to_ftp_on_https_failure(monkeypatch, tmp_path):
+def test_download_single_file_fails_fast_on_pds_failure(monkeypatch, tmp_path):
     track_id = "20200101T000000"
     track_time = pd.to_datetime(track_id)
     remote_base_name = "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST"
@@ -284,9 +257,14 @@ def test_download_single_file_falls_back_to_ftp_on_https_failure(monkeypatch, tm
         lambda **kwargs: (_ for _ in ()).throw(RuntimeError("https failure")),
     )
     monkeypatch.setattr(
-        l1b, "_download_single_file_via_ftp", lambda track_id: "ftp-path"
+        l1b,
+        "_download_single_file_via_ftp",
+        lambda track_id: (_ for _ in ()).throw(
+            AssertionError("FTP fallback must not be used")
+        ),
     )
-    assert l1b.download_single_file(track_id) == "ftp-path"
+    with pytest.raises(RuntimeError, match="enhancement #76"):
+        l1b.download_single_file(track_id)
 
 
 def test_download_wrapper_returns_failure_when_worker_fails(monkeypatch):
@@ -304,12 +282,9 @@ def test_download_wrapper_returns_failure_when_worker_fails(monkeypatch):
     assert result == 1
 
 
-def test_download_files_uses_https_and_falls_back_for_unresolved_tracks(
-    monkeypatch, tmp_path
-):
+def test_download_files_fails_fast_for_unresolved_tracks(monkeypatch, tmp_path):
     track_idx = pd.DatetimeIndex(["2020-01-01 00:00:00", "2020-01-02 00:00:00"])
     resolved_track = track_idx[0]
-    unresolved_track = track_idx[1]
     remote_base_name = "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST"
     monkeypatch.setattr(l1b, "l1b_path", str(tmp_path))
     monkeypatch.setattr(
@@ -321,32 +296,32 @@ def test_download_files_uses_https_and_falls_back_for_unresolved_tracks(
         lambda idx: pd.Series({resolved_track: remote_base_name}),
     )
     https_calls = []
-    ftp_calls = []
     session = DummySession()
 
     def fake_https(remote_file, local_path, session, href=None):
         https_calls.append((remote_file, Path(local_path), session))
         return str(local_path)
 
-    def fake_ftp(track_idx, stop_event=None):
-        ftp_calls.append(pd.DatetimeIndex(track_idx))
-
     monkeypatch.setattr(l1b, "_create_esa_https_session", lambda auth: session)
     monkeypatch.setattr(l1b, "_download_named_file_https", fake_https)
-    monkeypatch.setattr(l1b, "_download_files_via_ftp", fake_ftp)
-    l1b.download_files(track_idx)
+    monkeypatch.setattr(
+        l1b,
+        "_download_files_via_ftp",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("FTP fallback must not be used")
+        ),
+    )
+    with pytest.raises(RuntimeError, match="20200102T000000"):
+        l1b.download_files(track_idx)
     assert len(https_calls) == 1
     assert https_calls[0][0] == remote_base_name + ".nc"
     assert https_calls[0][2] is session
-    assert len(ftp_calls) == 1
-    assert unresolved_track in ftp_calls[0]
-    assert resolved_track not in ftp_calls[0]
+    assert session.closed
     assert session.closed
 
 
-def test_download_files_uses_ftp_when_https_auth_is_unavailable(monkeypatch):
+def test_download_files_fails_fast_when_pds_auth_is_unavailable(monkeypatch):
     track_idx = pd.DatetimeIndex(["2020-01-01 00:00:00", "2020-01-02 00:00:00"])
-    ftp_calls = []
     monkeypatch.setattr(
         l1b,
         "_resolve_esa_ftp_credentials",
@@ -362,13 +337,12 @@ def test_download_files_uses_ftp_when_https_auth_is_unavailable(monkeypatch):
     monkeypatch.setattr(
         l1b,
         "_download_files_via_ftp",
-        lambda track_idx, stop_event=None: ftp_calls.append(
-            pd.DatetimeIndex(track_idx)
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("FTP fallback must not be used")
         ),
     )
-    l1b.download_files(track_idx)
-    assert len(ftp_calls) == 1
-    assert ftp_calls[0].equals(track_idx)
+    with pytest.raises(RuntimeError, match="PDS HTTPS credentials"):
+        l1b.download_files(track_idx)
 
 
 def test_download_files_reuses_one_https_session_for_batch(monkeypatch, tmp_path):
@@ -395,14 +369,6 @@ def test_download_files_reuses_one_https_session_for_batch(monkeypatch, tmp_path
 
     monkeypatch.setattr(l1b, "_create_esa_https_session", lambda auth: session)
     monkeypatch.setattr(l1b, "_download_named_file_https", fake_https)
-    monkeypatch.setattr(
-        l1b,
-        "_download_files_via_ftp",
-        lambda track_idx, stop_event=None: (_ for _ in ()).throw(
-            AssertionError("FTP fallback should not be used")
-        ),
-    )
-
     l1b.download_files(track_idx)
 
     assert [call[0] for call in session_calls] == [
@@ -428,12 +394,6 @@ def test_download_named_file_https_rejects_html_payload(monkeypatch, tmp_path):
             ),
         ]
     )
-    monkeypatch.setattr(
-        l1b,
-        "_resolve_l1b_enclosure_href",
-        lambda value, timeout=120: "https://science-pds.cryosat.esa.int/test.nc",
-    )
-
     with pytest.raises(RuntimeError, match="HTML/XML"):
         l1b._download_named_file_https(
             remote_file=remote_file,
@@ -454,17 +414,12 @@ def test_download_named_file_https_accepts_netcdf4_magic(monkeypatch, tmp_path):
             )
         ]
     )
-    monkeypatch.setattr(
-        l1b,
-        "_resolve_l1b_enclosure_href",
-        lambda value, timeout=120: "https://science-pds.cryosat.esa.int/test.nc",
-    )
     result = l1b._download_named_file_https(
         remote_file=remote_file,
         local_path=local_path,
         session=session,
     )
-    assert Path(result).name == "CS_LTA__SIR_SIN_1B_20200101T000000_TEST.nc"
+    assert Path(result).name == remote_file
 
 
 def test_l1b_product_name_candidates_prefer_lta_then_offl():
@@ -495,9 +450,7 @@ def test_select_lta_then_offl_for_track_raises_when_missing():
         )
 
 
-def test_download_named_file_https_falls_back_to_offl_when_lta_missing(
-    monkeypatch, tmp_path
-):
+def test_download_named_file_https_uses_pds_when_catalog_has_maap_href(tmp_path):
     remote_file = "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc"
     local_path = tmp_path / remote_file
     session = DummySession(
@@ -508,25 +461,14 @@ def test_download_named_file_https_falls_back_to_offl_when_lta_missing(
             )
         ]
     )
-    calls = []
-
-    def fake_resolve(value, timeout=120):
-        calls.append(value)
-        if value.startswith("CS_LTA__"):
-            raise FileNotFoundError("missing LTA")
-        return "https://science-pds.cryosat.esa.int/test.nc"
-
-    monkeypatch.setattr(l1b, "_resolve_l1b_enclosure_href", fake_resolve)
     result = l1b._download_named_file_https(
         remote_file=remote_file,
         local_path=local_path,
         session=session,
+        href="https://catalog.maap.eo.esa.int/data/cryosat/example.nc",
     )
     assert result == str(local_path)
-    assert calls == [
-        "CS_LTA__SIR_SIN_1B_20200101T000000_TEST.nc",
-        "CS_OFFL_SIR_SIN_1B_20200101T000000_TEST.nc",
-    ]
+    assert session.get_calls[0][0] == l1b._pds_l1b_download_url(remote_file)
 
 
 def test_download_remote_file_via_ftp_atomic_success(tmp_path):

--- a/tests/test_stac_track_catalog.py
+++ b/tests/test_stac_track_catalog.py
@@ -106,7 +106,7 @@ def test_stac_catalog_warns_and_excludes_unsupported_baselines():
     assert catalog.empty
 
 
-def test_stac_query_uses_provider_fallback_and_pagination(monkeypatch):
+def test_stac_query_uses_maap_pagination(monkeypatch):
     calls = []
     first_item = _item("CS_OFFL_SIR_SIN_1B_20200101T000000_20200101T000200_E001")
     second_item = _item(
@@ -116,9 +116,9 @@ def test_stac_query_uses_provider_fallback_and_pagination(monkeypatch):
 
     def fake_get(url, params=None, timeout=None):
         calls.append((url, params, timeout))
-        if "eocat" in url:
-            raise RuntimeError("eocat down")
         if params is not None:
+            assert "maap" in url
+            assert params["collections"] == "CryoSatIceL110"
             assert params["productType"] == "SIR_SIN_1B"
             assert params["sensorMode"] == "SARIN"
             return DummyResponse(
@@ -137,7 +137,39 @@ def test_stac_query_uses_provider_fallback_and_pagination(monkeypatch):
 
     assert len(catalog) == 2
     assert list(catalog["provider"].unique()) == ["maap"]
-    assert len(calls) == 3
+    assert len(calls) == 2
+
+
+def test_stac_query_prefers_maap_and_uses_its_collection(monkeypatch):
+    calls = []
+    item = _item(
+        "CS_OFFL_SIR_SIN_1B_20220917T082319_20220917T082404_E001",
+        start="2022-09-17T08:23:19Z",
+        end="2022-09-17T08:24:05Z",
+        href=(
+            "https://catalog.maap.eo.esa.int/data/cryosat-pdgs-01/CRYOSAT/"
+            "SIR_SIN_1B/E001/2022/09/17/example.nc"
+        ),
+    )
+    item["assets"] = {"enclosure_nc": item["assets"].pop("enclosure")}
+
+    def fake_get(url, params=None, timeout=None):
+        calls.append((url, params, timeout))
+        if "maap" not in url:
+            return DummyResponse({"features": []})
+        assert params["collections"] == "CryoSatIceL110"
+        return DummyResponse({"features": [item], "links": []})
+
+    monkeypatch.setattr(misc.requests, "get", fake_get)
+
+    catalog = misc._query_stac_l1b_track_catalog(
+        pd.Timestamp("2022-09-17T08:23:19"),
+        pd.Timestamp("2022-09-17T08:24:05"),
+    )
+
+    assert list(catalog["provider"].unique()) == ["maap"]
+    assert catalog.iloc[0]["href"].endswith("example.nc")
+    assert len(calls) == 1
 
 
 def test_load_cs_full_file_names_overlays_stac_catalog(monkeypatch, tmp_path):


### PR DESCRIPTION
Use MAAP CryoSat STAC metadata with authenticated PDS HTTPS delivery for L1b downloads, and fail fast rather than automatically falling back to FTP.